### PR TITLE
Reusable Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -35,7 +35,16 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
+            Please review this pull request. Draw on your experience as a seasoned, team-oriented
+            engineer.
 
+            You are evaluating the pull request as submitted, not elaborating on it.
+            Do not explain the content of the pull request, unless it is to explain what is missing.
+            Explain whether the pull request summary makes sense, and whether the change in the
+            pull request does what the summary says.
+
+            Give a concise, dispassionate summary of your evaluation, and the recommended next step.
+            Summarise the main pros and cons and support them with evidence.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -1,7 +1,12 @@
 name: Claude Code Review
 
 on:
-  workflow_call: {}
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: A Claude Code access token. Supply this **or** ANTHROPIC_API_KEY.
+      ANTHROPIC_API_KEY:
+        description: An API key from the Anthropic console. Supply this **or** CLAUDE_CODE_OAUTH_TOKEN.
 
 jobs:
   claude-review:
@@ -23,13 +28,14 @@ jobs:
         uses: anthropics/claude-code-action@7145c3e0510bcdbdd29f67cc4a8c1958f1acfa2f # v1.0.27
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           # Direct prompt for automated review (no @claude mention needed)
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            
+
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -1,0 +1,39 @@
+name: Claude Code Review
+
+on:
+  workflow_call: {}
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write # needed to get an OIDC access token for Claude to use
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@7145c3e0510bcdbdd29f67cc4a8c1958f1acfa2f # v1.0.27
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          # Direct prompt for automated review (no @claude mention needed)
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            
+
+          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
+          use_sticky_comment: true
+
+          # Configuration via CLI arguments
+          claude_args: |
+            --allowedTools Bash(make test-unit),Bash(make lint),Bash(make validate)


### PR DESCRIPTION
This takes the Claude workflow definition as it is in https://github.com/nscaledev/uni-region/pull/381, tweaks it a little to make it more robust when files aren't present, and puts it in a `workflow_call` trigger.

This means you can call it from another repo, and it'll act locally; and _that_ means we can have centralised prompts (as below), but local guidelines (as in CLAUDE.md), which makes it much easier to evolve our reviews.

Fixes INST-545.