### PR TITLE
Quote allowedTools for Claude

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -51,4 +51,4 @@ jobs:
 
           # Configuration via CLI arguments
           claude_args: |
-            --allowedTools Bash(make test-unit),Bash(make lint),Bash(make validate)
+            --allowedTools "Bash(make test-unit),Bash(make lint),Bash(make validate)"


### PR DESCRIPTION
It appears to split over spaces and get completely the wrong idea. This is from the transcript before the quoting:

https://github.com/nscaledev/uni-shared-workflow-tester/actions/runs/24249529849/job/70804775306#step:3:635

```
SDK options: {
  "allowedTools": [
    "Edit",
    "MultiEdit",
    "Glob",
    "Grep",
    "LS",
    "Read",
    "Write",
    "mcp__github_comment__update_claude_comment",
    "mcp__github_ci__get_ci_status",
    "mcp__github_ci__get_workflow_run_details",
    "mcp__github_ci__download_job_log",
    "Bash(git add:*)",
    "Bash(git commit:*)",
    "Bash(git push:*)",
    "Bash(git status:*)",
    "Bash(git diff:*)",
    "Bash(git log:*)",
    "Bash(git rm:*)",
    "Bash",
    "make",
    "test-unit",
    "lint",
    "validate"
  ],
```

and this is from after:

https://github.com/nscaledev/uni-shared-workflow-tester/actions/runs/24668566833/job/72132675722#step:3:589

```
SDK options: {
  "allowedTools": [
    "Edit",
    "MultiEdit",
    "Glob",
    "Grep",
    "LS",
    "Read",
    "Write",
    "mcp__github_comment__update_claude_comment",
    "mcp__github_ci__get_ci_status",
    "mcp__github_ci__get_workflow_run_details",
    "mcp__github_ci__download_job_log",
    "Bash(git add:*)",
    "Bash(git commit:*)",
    "Bash(git push:*)",
    "Bash(git status:*)",
    "Bash(git diff:*)",
    "Bash(git log:*)",
    "Bash(git rm:*)",
    "Bash(make test-unit)",
    "Bash(make lint)",
    "Bash(make validate)"
  ],
```
