### PR TITLE
Put commit hygeine instructions in review prompt

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -43,6 +43,11 @@ jobs:
             Explain whether the pull request summary makes sense, and whether the change in the
             pull request does what the summary says.
 
+            Check that each commit has a sensible message:
+            - The subject (first line) should not have a "conventional commit" prefix
+            - The subject should be limited to 50 characters, and be in imperative mood
+            - The commit message body should be wrapped at 72 characters
+
             Give a concise, dispassionate summary of your evaluation, and the recommended next step.
             Summarise the main pros and cons and support them with evidence.
 


### PR DESCRIPTION
In an attempt to get consistency with commit messages, I've put some instructions here. These are a summary of https://cbea.ms/git-commit/.

Note that "conventional commit" is explicitly excluded. It's no good having them sprinkled through the git history; and if I have to choose, I choose to omit the noise of those prefixes. They are not used in these repos, and I'd argue would not be usable (since they are often on commits that are squashed anyway, aren't always accurate, and take up space that could be a more thoughtful commit message.)
